### PR TITLE
Fixed an invalid example in documentation

### DIFF
--- a/docs/api/client/servers.md
+++ b/docs/api/client/servers.md
@@ -910,7 +910,11 @@ const response = await axios.get(\`https://your-panel.com/api/client/servers/\${
 const { token, socket } = response.data.data;
 
 // Connect to WebSocket
-const ws = new WebSocket(socket);
+const ws = new WebSocket(socket, {
+  headers: {
+    "Origin": "https://your-panel.com"
+  }
+});
 
 ws.on('open', () => {
   // Authenticate


### PR DESCRIPTION
## 📋 Pull Request Description
There is no "origin" header in the example of the documentation and the wings will basically refuse to let connect the client without it.

### 📖 What does this PR do?
It fix the issue of documentation.